### PR TITLE
Problem: systemd config is not set

### DIFF
--- a/src/fty-discovery.service.in
+++ b/src/fty-discovery.service.in
@@ -3,8 +3,8 @@
 
 [Unit]
 Description=fty-discovery service
-After=malamute.service network.target 
-Requires=malamute.service network.target 
+After=malamute.service network.target bios-db-init.service 
+Requires=malamute.service network.target bios-db-init.service
 PartOf=bios.target
 
 [Service]

--- a/src/fty-discovery.service.in
+++ b/src/fty-discovery.service.in
@@ -3,19 +3,18 @@
 
 [Unit]
 Description=fty-discovery service
-After=network.target
-# Requires=network.target
-# Conflicts=shutdown.target
-# PartOf=fty-discovery.target
+After=malamute.service network.target 
+Requires=malamute.service network.target 
+PartOf=bios.target
 
 [Service]
 Type=simple
-# User=@uid@
+User=bios
+Environment="PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/lib/nut:"
 Environment="prefix=@prefix@"
 Environment='SYSTEMD_UNIT_FULLNAME=%n'
 ExecStart=@prefix@/bin/fty-discovery @sysconfdir@/@PACKAGE@/fty-discovery.cfg
 Restart=always
 
 [Install]
-WantedBy=multi-user.target
-# WantedBy=fty-discovery.target
+WantedBy=bios.target


### PR DESCRIPTION
Problem : malamute dependency is missing
Solution : add it

Problem : this service is part of bios.target
Solution : fix it

Problem : this service needs to access dummy-ups, netxml-ups, snmp-ups and nut-scanner
Solution : set PATH

Signed-off-by: Gerald Guillaume <geraldguillaume@eaton.com>