### PR TITLE
Remove empty credential set fallback

### DIFF
--- a/src/scan_nut.cc
+++ b/src/scan_nut.cc
@@ -525,8 +525,8 @@ scan_nut_actor(zsock_t *pipe, void *args)
     }
 
     std::vector<CredentialProtocolScanResult> results;
-    const auto credentialsV3 = documentNames->empty() ? nutcommon::getCredentialsSNMPv3() : nutcommon::getCredentialsSNMPv3(*documentNames);
-    const auto credentialsV1 = documentNames->empty() ? nutcommon::getCredentialsSNMPv1() : nutcommon::getCredentialsSNMPv1(*documentNames);
+    const auto credentialsV3 = nutcommon::getCredentialsSNMPv3(*documentNames);
+    const auto credentialsV1 = nutcommon::getCredentialsSNMPv1(*documentNames);
 
     // Grab timeout.
     int timeout;


### PR DESCRIPTION
To be merged once UI is updated, in order not to break auto-discovery.