### PR TITLE
Problem: Discovery not using DNS information

### DIFF
--- a/src/scan_dns.cc
+++ b/src/scan_dns.cc
@@ -1,7 +1,7 @@
 /*  =========================================================================
     scan_dns - collect information from DNS
 
-    Copyright (C) 2014 - 2017 Eaton
+    Copyright (C) 2014 - 2019 Eaton
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -47,12 +47,18 @@ scan_dns (fty_proto_t *msg, const char *address, zconfig_t *config)
 
     if (! getnameinfo(sa, len, dns_name, sizeof(dns_name), NULL, 0, NI_NAMEREQD)) {
         fty_proto_ext_insert (msg, "dns.1", "%s", dns_name);
+        log_debug("Retrieved DNS information");
+        log_debug("FQDN = '%s'", dns_name);
         char *p = strchr (dns_name, '.');
         if (p) {
             *p = 0;
         }
         fty_proto_ext_insert (msg, "hostname", "%s", dns_name);
+        log_debug("Hostname = '%s'", dns_name);
         return true;
+    }
+    else {
+        log_debug("No host information retrieved from DNS");
     }
     return false;
 }

--- a/src/scan_nut.cc
+++ b/src/scan_nut.cc
@@ -155,6 +155,9 @@ s_nut_dumpdata_to_fty_message(std::vector<fty_proto_t*>& assets, const nutcommon
             fty_proto_ext_insert(fmsg, property.first.c_str(), "%s", property.second.c_str());
         }
 
+        // Try to obtain DNS name ("hostname" + "dns.1" attributes)
+        scan_dns (fmsg, ip.c_str(), NULL);
+
         // Some special cases.
         fty_proto_ext_insert(fmsg, "ip.1", "%s", ip.c_str());
         fty_proto_aux_insert(fmsg, "type", "%s", type.c_str());


### PR DESCRIPTION
Solution: When available, use DNS information

This results, when available, in using the DNS provided hostname
instead of the forged "<subtype> (<ip address)", and otherwise fallback
to the forged version

Signed-off-by: Arnaud Quette <ArnaudQuette@Eaton.com>
(cherry picked from commit 6564599c6abaf37c4bbefef05515eb6138914567)