### PR TITLE
fty-discovery.service.in: source the ecosystem usual EnvironmentFile and fix PATH

### DIFF
--- a/src/fty-discovery.service.in
+++ b/src/fty-discovery.service.in
@@ -16,7 +16,7 @@ EnvironmentFile=-@sysconfdir@/default/bios
 EnvironmentFile=-@sysconfdir@/default/bios__%n.conf
 EnvironmentFile=-@sysconfdir@/default/fty
 EnvironmentFile=-@sysconfdir@/default/fty__%n.conf
-Environment="PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/lib/nut:"
+Environment="PATH=/usr/sbin:/usr/bin:/sbin:/bin:/lib/nut"
 Environment="prefix=@prefix@"
 Environment='SYSTEMD_UNIT_FULLNAME=%n'
 Environment="NUT_ALTPIDPATH=\"\""

--- a/src/fty-discovery.service.in
+++ b/src/fty-discovery.service.in
@@ -8,6 +8,14 @@ PartOf=bios.target
 [Service]
 Type=simple
 User=discovery-monitoring-daemon
+EnvironmentFile=-@prefix@/share/bios/etc/default/bios
+EnvironmentFile=-@prefix@/share/bios/etc/default/bios__%n.conf
+EnvironmentFile=-@prefix@/share/fty/etc/default/fty
+EnvironmentFile=-@prefix@/share/fty/etc/default/fty__%n.conf
+EnvironmentFile=-@sysconfdir@/default/bios
+EnvironmentFile=-@sysconfdir@/default/bios__%n.conf
+EnvironmentFile=-@sysconfdir@/default/fty
+EnvironmentFile=-@sysconfdir@/default/fty__%n.conf
 Environment="PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/lib/nut:"
 Environment="prefix=@prefix@"
 Environment='SYSTEMD_UNIT_FULLNAME=%n'


### PR DESCRIPTION
The service file as delivered does not mention the usual stack of EnvironmentFile’s we have, so does not know about configured settings for the image (`BIOS_LOG_LEVEL=LOG_INFO` from `/usr/share/fty/etc/default/fty` on "deploy" image types) and logs all debugs even in end-user environments, which is wasteful at least.

Also the hardcoded PATH setting was somewhat strange:
* We do not deliver things in `/usr/local/{bin,sbin}/` - at least not what this service would need
* The trailing semicolon in PATH may be interpreted as looking in current working directory, which may have been intended (reviewers welcome to this spot!) but generally unsafe