### PR TITLE
Fix parent iname conversion

### DIFF
--- a/src/fty_discovery_server.cc
+++ b/src/fty_discovery_server.cc
@@ -354,7 +354,14 @@ bool compute_configuration_file(fty_discovery_server_t *self) {
     section = zconfig_locate(config, CFG_DISCOVERY_DEFAULT_VALUES_AUX);
     if (section) {
         for (zconfig_t *item = zconfig_child(section); item; item = zconfig_next(item)) {
-            self->default_values_aux[zconfig_name(item)] = zconfig_value(item);
+            std::string configName(zconfig_name(item));
+            // the config API call returns the parent internal name, while fty-proto-t needs to carry the database ID
+            if(configName == "parent") {
+                std::string parentIname(zconfig_value(item));
+                self->default_values_aux[zconfig_name(item)] = (parentIname == "0" || parentIname == "") ? "0" : std::to_string(DBAssets::name_to_asset_id(parentIname)).c_str();
+            } else {
+                self->default_values_aux[zconfig_name(item)] = zconfig_value(item);
+            }
         }
     }
     self->default_values_ext.clear();


### PR DESCRIPTION
`fty-discovery` configuration stores the internal name of the asset, while `fty-proto` requires the integer ID of the asset

Signed-off-by: Mauro Guerrera <mauroguerrera@eaton.com>